### PR TITLE
Define the `PollingExecutionContextScheduler` API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [3.1.3]
+        scala: [2.13.9]
         java: [temurin@8]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,8 +4,6 @@ style = default
 
 runner.dialect = scala213source3
 
-docstrings.wrap = "no"
-
 maxColumn = 100
 
 rewrite.rules = [

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.0"
+ThisBuild / tlBaseVersion := "1.0"
 
 ThisBuild / organization := "com.armanbilge"
 ThisBuild / organizationName := "Scala Native Polling Execution Context Scheduler Working Group"
@@ -9,6 +9,7 @@ ThisBuild / startYear := Some(2022)
 ThisBuild / tlSonatypeUseLegacyHost := false
 
 val scala213 = "2.13.9"
+ThisBuild / scalaVersion := scala213
 ThisBuild / crossScalaVersions := Seq("2.11.12", "2.12.17", scala213, "3.1.3")
 
 lazy val core = project

--- a/core/src/main/scala/com/armanbilge/snpecs/Polling.scala
+++ b/core/src/main/scala/com/armanbilge/snpecs/Polling.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2022 Scala Native Polling Execution Context Scheduler Working Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.armanbilge.snpecs
+
+trait Polling {
+
+  /** Registers a callback to be notified of read- and write-ready events on a file descriptor.
+    * Produces a runnable which unregisters the file descriptor.
+    *
+    *   1. It is the responsibility of the caller to set the file descriptor to non-blocking mode.
+    *   1. It is the responsibility of the caller to unregister the file descriptor when they are
+    *      done. There is nobody to cleanup after your mess.
+    *   1. A file descriptor should be registered at most once. To modify a registration, you must
+    *      unregister and re-register the file descriptor.
+    *   1. The callback may be invoked "spuriously" claiming that a file descriptor is read- or
+    *      write-ready when in fact it is not. You should be prepared to handle this.
+    *   1. The callback will be invoked at least once when the file descriptor transitions from
+    *      blocked to read- or write-ready. You may additionally receive zero or more reminders of
+    *      its readiness. However, you should not expect any further callbacks until after the file
+    *      descriptor has become blocked again.
+    */
+  def register(fileDescriptor: Int, readReady: Boolean, writeReady: Boolean)(
+      cb: Polling.Callback
+  ): Runnable
+
+}
+
+object Polling {
+
+  trait Callback {
+    def apply(readReady: Boolean, writeReady: Boolean): Unit
+  }
+
+}

--- a/core/src/main/scala/com/armanbilge/snpecs/Polling.scala
+++ b/core/src/main/scala/com/armanbilge/snpecs/Polling.scala
@@ -30,7 +30,7 @@ trait Polling {
     *      write-ready when in fact it is not. You should be prepared to handle this.
     *   1. The callback will be invoked at least once when the file descriptor transitions from
     *      blocked to read- or write-ready. You may additionally receive zero or more reminders of
-    *      its readiness. However, you should not expect any further callbacks until after the file
+    *      its readiness. However, you should not rely on any further callbacks until after the file
     *      descriptor has become blocked again.
     */
   def register(fileDescriptor: Int, readReady: Boolean, writeReady: Boolean)(

--- a/core/src/main/scala/com/armanbilge/snpecs/PollingExecutionContextScheduler.scala
+++ b/core/src/main/scala/com/armanbilge/snpecs/PollingExecutionContextScheduler.scala
@@ -41,7 +41,7 @@ object PollingExecutionContextScheduler {
       false
     }
 
-  /** '''DO NOT USE THIS!!!''' Instead you should request an [[PollingExecutionContextScheduler]] as
+  /** '''DO NOT USE THIS!!!''' Instead you should request a [[PollingExecutionContextScheduler]] as
     * an explicit or implicit parameter of your API.
     *
     * There is exactly one situation to explicitly rely on the [[global]]: you are implementing JDK

--- a/core/src/main/scala/com/armanbilge/snpecs/PollingExecutionContextScheduler.scala
+++ b/core/src/main/scala/com/armanbilge/snpecs/PollingExecutionContextScheduler.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2022 Scala Native Polling Execution Context Scheduler Working Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.armanbilge.snpecs
+
+import scala.concurrent.ExecutionContext
+
+trait PollingExecutionContextScheduler extends Polling with ExecutionContext with Scheduler
+
+object PollingExecutionContextScheduler {
+
+  private[this] var _global: PollingExecutionContextScheduler = null
+
+  /** Install a [[PollingExecutionContextScheduler]] as the [[global]]. You should do this as early
+    * as possible in your application, before calling anything that may need it (i.e. JDK NIO APIs).
+    *
+    * The first time this method is called, the given [[PollingExecutionContextScheduler]] will be
+    * installed and it will return `true`. All subsequent invocations will no-op and return `false`.
+    *
+    * This method should be called ''exactly'' once in an application. A library should never call
+    * this method.
+    */
+  def installGlobal(global: => PollingExecutionContextScheduler): Boolean =
+    if (_global == null) {
+      _global = global
+      true
+    } else {
+      false
+    }
+
+  /** '''DO NOT USE THIS!!!''' Instead you should request an [[PollingExecutionContextScheduler]] as
+    * an explicit or implicit parameter of your API.
+    *
+    * There is exactly one situation to explicitly rely on the [[global]]: you are implementing JDK
+    * APIs, in which case it would be impossible to obtain a [[PollingExecutionContextScheduler]] by
+    * any other means.
+    *
+    * Otherwise, '''STAY AWAY!!!'''
+    */
+  def global: PollingExecutionContextScheduler = _global
+
+}

--- a/core/src/main/scala/com/armanbilge/snpecs/Scheduler.scala
+++ b/core/src/main/scala/com/armanbilge/snpecs/Scheduler.scala
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Scala Native Polling Execution Context Scheduler Working Group
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.armanbilge.snpecs
+
+import scala.concurrent.duration.FiniteDuration
+
+trait Scheduler {
+
+  /** Schedules a callback to run after the delay interval. Produces a runnable which cancels the
+    * scheduling.
+    */
+  def schedule(delay: FiniteDuration, callback: Runnable): Runnable
+
+}


### PR DESCRIPTION
This PR defines the API for a `PollingExecutionContextScheduler`, which offers methods to:
- `execute` a task, effectively immediately;
- `schedule` a callback to be invoked in the future; and
- `register` to be notified of read- and write-ready events on a file descriptor

### Expected implementors
- the libuv runtime in scala-native-loop
- the epoll runtime in epollcat
- the kqueue runtime in epollcat
- the io_uring runtime in fs2-io_uring
- the cURL runtime in http4s-curl

### Expected consumers
- snunit
- scala-native-http-client-async
- epollcat JDK NIO implementations

**If we do this right, then it means that any application using a runtime that implements this API would be fully interoperable with any library that consumes this API.**

I have invited the following collaborators to this project:
- @ekrich, representing Scala Native core
- @lolgab, representing scala-native-loop, snunit, and scala-native-http-client-async
- @sideeffffect, representing ZIO
- @keynmol, representing the goal to have "**one** cross-OS artifact that users can use which will do various epoll/kqueue/iouring things **under the hood**"

Of course, feedback is welcome from any and all onlookers as well. Particularly those that know better than me 😅 

Everything subject to question, debate, bikeshed, etc. Thanks!